### PR TITLE
Fix default user interaction timeout only 6 seconds

### DIFF
--- a/lib/public/webeid/authenticate.js
+++ b/lib/public/webeid/authenticate.js
@@ -58,8 +58,13 @@ function init() {
   ui.result.value                       = "";
 
   ui.authButton.addEventListener("click", async () => {
-    const userInteractionTimeout  = ui.userInteractionTimeout.value;
-    const lang                    = ui.authLanguage.value;
+    const userInteractionTimeout  = (
+      ui.userInteractionTimeout.value
+        ? parseInt(ui.userInteractionTimeout.value)
+        : undefined
+    );
+
+    const lang = ui.authLanguage.value;
 
     ui.result.value = "";
     ui.authButton.disabled = true;

--- a/lib/public/webeid/sign.js
+++ b/lib/public/webeid/sign.js
@@ -58,8 +58,13 @@ function init() {
   ui.result.value                        = "";
 
   ui.signButton.addEventListener("click", async () => {
-    const userInteractionTimeout = ui.userInteractionTimeout.value;
-    const lang                   = ui.signLanguage.value;
+    const userInteractionTimeout  = (
+      ui.userInteractionTimeout.value
+        ? parseInt(ui.userInteractionTimeout.value)
+        : undefined
+    );
+
+    const lang = ui.signLanguage.value;
 
     ui.result.value = "";
     ui.signButton.disabled = true;


### PR DESCRIPTION
UserInteractionTimeout option is now stricter in web-eid.js and doesn't allow empty string as a value.

WE2-1048
